### PR TITLE
Add support for query parameters for instant query from URL bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,22 @@
 import './App.scss';
 import { Tabs, TabPanel } from './components/Tabs';
 import Start  from './Start';
-import BookSearch from './BookSearch';
+import BookSearch, { BookSearchProps } from './BookSearch';
 import LibraryEditList from './LibraryEditList';
 import LibrarySearch from './LibrarySearch';
 import { useLibraryContext } from './context/LibraryContext';
 
+function getBookSearchPropsFromURL(): BookSearchProps {
+  const params = new URLSearchParams(window.location.search);
+  return {
+    initialQuery: params.get('q') || ''
+  };
+}
+
 function App() {
   const {state} = useLibraryContext();
+
+  const { initialQuery } = getBookSearchPropsFromURL();
 
   return (
 
@@ -28,7 +37,7 @@ function App() {
             <LibraryEditList/>
           </TabPanel>
           <TabPanel title="Find Books"  disabled={state.libraries.length===0}>
-            <BookSearch/>
+            <BookSearch initialQuery={initialQuery} />
           </TabPanel>
         </Tabs>
       </main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import './App.scss';
+import { useEffect, useState } from 'react';
 import { Tabs, TabPanel } from './components/Tabs';
 import Start  from './Start';
 import BookSearch, { BookSearchProps } from './BookSearch';
@@ -15,18 +16,31 @@ function getBookSearchPropsFromURL(): BookSearchProps {
 
 function App() {
   const {state} = useLibraryContext();
-
   const { initialQuery } = getBookSearchPropsFromURL();
 
-  return (
+  const getInitialTab = () => {
+    if (state.libraries.length === 0) return 0;
+    return 1;
+  };
 
+  const [tabIndex, setTabIndex] = useState(getInitialTab());
+  const [autoSwitched, setAutoSwitched] = useState(false);
+
+  useEffect(() => {
+    if (!autoSwitched && initialQuery !== "" && state.libraries.length > 0) {
+      setTabIndex(3);
+      setAutoSwitched(true);
+    }
+  }, [state.libraries, initialQuery, autoSwitched]);
+
+  return (
     <div className="App">
       <header className="App-header">
         <h1>Libby Multi-Library Search</h1>
       </header>
 
       <main>
-        <Tabs defaultTabIndex={state.libraries.length === 0 ? 0 : 1}>
+        <Tabs tabIndex={tabIndex} setTabIndex={setTabIndex}>
           <TabPanel title="Start">
             <Start/>
           </TabPanel>
@@ -41,7 +55,6 @@ function App() {
           </TabPanel>
         </Tabs>
       </main>
-
     </div>
   );
 }

--- a/src/BookSearch.tsx
+++ b/src/BookSearch.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLibraryContext } from './context/LibraryContext';
 import { findBooks } from './utils/DataTools';
 import { BookFormatType, BookFormatListType } from './types';
@@ -13,10 +13,14 @@ import time from './img/time.svg';
 import check from './img/check.svg'
 
 
-function BookSearch () {
+export type BookSearchProps = {
+  initialQuery?: string;
+};
+
+function BookSearch ({ initialQuery }: BookSearchProps) {
   const {state} = useLibraryContext();
   const [formats, setFormats] = useState<BookFormatListType>(['ebook', 'audiobook', 'magazine']);
-  const [searchQuery, setSearchQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState(initialQuery || '');
   const [searchResults, setSearchResults] = useState<any>([]);
 
   enum SearchStatus {
@@ -26,6 +30,13 @@ function BookSearch () {
   }
 
   const [searchStatus, setSearchStatus] = useState(SearchStatus.Idle);
+
+  // Run search on mount if initialQuery is present
+  useEffect(() => {
+    if (initialQuery && initialQuery.trim().length > 0) {
+      search();
+    }
+  }, []);
 
   const updateFormats = (format: BookFormatType, isEnabled: boolean) => {
     if (isEnabled) {

--- a/src/BookSearch.tsx
+++ b/src/BookSearch.tsx
@@ -31,12 +31,15 @@ function BookSearch ({ initialQuery }: BookSearchProps) {
 
   const [searchStatus, setSearchStatus] = useState(SearchStatus.Idle);
 
-  // Run search on mount if initialQuery is present
+  // Run search when both initialQuery and libraries are present (and only once)
+  const [initialSearchDone, setInitialSearchDone] = useState(false);
   useEffect(() => {
-    if (initialQuery && initialQuery.trim().length > 0) {
+    if (!initialSearchDone && initialQuery && initialQuery.trim().length > 0 && state.libraries.length > 0) {
       search();
+      setInitialSearchDone(true);
     }
-  }, []);
+    // eslint-disable-next-line
+  }, [initialQuery, state.libraries]);
 
   const updateFormats = (format: BookFormatType, isEnabled: boolean) => {
     if (isEnabled) {

--- a/src/components/Tabs.test.tsx
+++ b/src/components/Tabs.test.tsx
@@ -1,27 +1,35 @@
 import { render, fireEvent } from '@testing-library/react';
 import { Tabs, TabPanel } from './Tabs';
+import { useState } from 'react';
 
 describe('Tabs', () => {
 
-  test('renders with correct number of tabs and default tab selected', () => {
+  test('renders with correct number of tabs and the first tab selected by default (uncontrolled)', () => {
     const { getByText } = render(
-      <Tabs defaultTabIndex={1}>
+      <Tabs>
         <TabPanel title="Tab 1">Content 1</TabPanel>
         <TabPanel title="Tab 2">Content 2</TabPanel>
         <TabPanel title="Tab 3">Content 3</TabPanel>
       </Tabs>
     );
 
-    expect(getByText('Tab 1').closest('button')).toBeInTheDocument();
+    const tab1 = getByText('Tab 1').closest('button');
     const tab2 = getByText('Tab 2').closest('button');
+    const tab3 = getByText('Tab 3').closest('button');
+    const panel1 = getByText('Content 1');
+
+    expect(tab1).toBeInTheDocument();
     expect(tab2).toBeInTheDocument();
-    if (tab2) expect(tab2.getAttribute('aria-current')).toBe('true');
-    expect(getByText('Tab 3').closest('button')).toBeInTheDocument();
+    expect(tab3).toBeInTheDocument();
+    if (tab1) expect(tab1.getAttribute('aria-current')).toBe('true');
+    if (tab2) expect(tab2.getAttribute('aria-current')).toBe('false');
+    if (tab3) expect(tab3.getAttribute('aria-current')).toBe('false');
+    expect(panel1).toHaveClass('tab-panel-active');
   });
 
-  test('changes active tab and displays corresponding panel on tab click', () => {
-    const { getByText, getByLabelText } = render(
-      <Tabs defaultTabIndex={0}>
+  test('changes active tab and displays corresponding panel on tab click (uncontrolled)', () => {
+    const { getByText } = render(
+      <Tabs>
         <TabPanel title="Tab 1">Content 1</TabPanel>
         <TabPanel title="Tab 2">Content 2</TabPanel>
         <TabPanel title="Tab 3">Content 3</TabPanel>
@@ -35,21 +43,36 @@ describe('Tabs', () => {
     const panel2 = getByText('Content 2');
     const panel3 = getByText('Content 3');
 
-    if (tab1) expect(tab1.getAttribute('aria-current')).toBe('true');
-    expect(panel1).toHaveClass('tab-panel-active');
-    if (tab2) expect(tab2.getAttribute('aria-current')).toBe('false');
-    expect(panel2).not.toHaveClass('tab-panel-active');
-    if (tab3) expect(tab3.getAttribute('aria-current')).toBe('false');
-    expect(panel3).not.toHaveClass('tab-panel-active');
-
     if (tab2) fireEvent.click(tab2);
 
+    // After clicking tab2, tab2 and panel2 should be active
     if (tab1) expect(tab1.getAttribute('aria-current')).toBe('false');
-    expect(panel1).not.toHaveClass('tab-panel-active');
     if (tab2) expect(tab2.getAttribute('aria-current')).toBe('true');
-    expect(panel2).toHaveClass('tab-panel-active');
     if (tab3) expect(tab3.getAttribute('aria-current')).toBe('false');
+    expect(panel1).not.toHaveClass('tab-panel-active');
+    expect(panel2).toHaveClass('tab-panel-active');
     expect(panel3).not.toHaveClass('tab-panel-active');
+  });
+
+  test('controlled: renders with specific tabIndex and responds to setTabIndex', () => {
+    // Simple controlled test wrapper
+    function ControlledTabs() {
+      const [tabIndex, setTabIndex] = useState(2);
+      return (
+        <Tabs tabIndex={tabIndex} setTabIndex={setTabIndex}>
+          <TabPanel title="Tab 1">Content 1</TabPanel>
+          <TabPanel title="Tab 2">Content 2</TabPanel>
+          <TabPanel title="Tab 3">Content 3</TabPanel>
+        </Tabs>
+      );
+    }
+    const { getByText } = render(<ControlledTabs />);
+    const tab3 = getByText('Tab 3').closest('button');
+    const panel3 = getByText('Content 3');
+    if (tab3) fireEvent.click(tab3);
+    expect(tab3).toBeInTheDocument();
+    expect(tab3 && tab3.getAttribute('aria-current')).toBe('true');
+    expect(panel3).toHaveClass('tab-panel-active');
   });
 
 });

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -4,45 +4,52 @@ import "./Tabs.scss";
 
 interface TabsProps {
   children: React.ReactElement<TabPanelProps>[];
-  defaultTabIndex?: number;
+  tabIndex?: number;
+  setTabIndex?: (n: number) => void;
 }
 
 function Tabs(props: TabsProps) {
-  const [activeTab, setActiveTab] = useState(props.children[props.defaultTabIndex||0].props.title);
+  // Setup for controlled/uncontrolled mode:
+  const isControlled = typeof props.tabIndex === 'number' && props.setTabIndex;
+  const [internalTabIndex, setInternalTabIndex] = useState(0);
+  const tabIndex = isControlled ? props.tabIndex! : internalTabIndex;
+  const setTabIndex = isControlled ? props.setTabIndex! : setInternalTabIndex;
+
   const tabsID = useId();
 
   return (
     <div className="tabs">
       <div className="tablist">
-        {props.children.map((child: React.ReactElement, index:number)=> {
+        {props.children.map((child: React.ReactElement, index: number) => {
           const { title, counter } = child.props;
-          const selected = activeTab === title;
+          const selected = tabIndex === index;
           return (
             <button
               id={tabsID + index + "-tab"}
-              onClick={() => setActiveTab(title)}
+              onClick={() => setTabIndex(index)}
               key={title}
               disabled={child.props.disabled}
               aria-current={selected}
               aria-controls={tabsID + index + "-panel"}
-              className={'tab ' + (selected ? "tab-active" : "")}>
-              <span>{title}</span>{typeof counter === 'number' && <CounterPill count={counter}/>}
+              className={'tab ' + (selected ? "tab-active" : "")}
+            >
+              <span>{title}</span>{typeof counter === 'number' && <CounterPill count={counter}/>} 
             </button>
           );
         })}
       </div>
-      {props.children.map((child:React.ReactElement, index:number) => {
-        const selected = activeTab === child.props.title;
+      {props.children.map((child: React.ReactElement, index: number) => {
+        const selected = tabIndex === index;
         return (
-        <div
-          id={tabsID + index + "-panel"}
-          aria-labelledby={tabsID + index + "-tab"}
-          className={'tab-panel ' + (selected ? "tab-panel-active" : "")}
-          key={child.props.title}
-        >
-          {child.props.children}
-        </div>
-        )
+          <div
+            id={tabsID + index + "-panel"}
+            aria-labelledby={tabsID + index + "-tab"}
+            className={'tab-panel ' + (selected ? "tab-panel-active" : "")}
+            key={child.props.title}
+          >
+            {child.props.children}
+          </div>
+        );
       })}
     </div>
   );

--- a/src/context/LibraryContext.tsx
+++ b/src/context/LibraryContext.tsx
@@ -11,8 +11,10 @@ export const initialState: AppState = {
 
 const syncPushState = (libraries: LibraryMetadataType[]) => {
   if (window.history.replaceState) {
-    var newurl =`${window.location.protocol}//${window.location.host}${window.location.pathname}?websiteIds=${libraries.map((lib) => lib.websiteId).join(',')}`;
-    window.history.replaceState({path:newurl},'',newurl);
+    const url = new URL(window.location.href);
+    url.searchParams.set('websiteIds', libraries.map((lib) => lib.websiteId).join(','));
+    var newurl = url.toString();
+    window.history.replaceState({ path: newurl }, '', newurl);
   }
 }
 


### PR DESCRIPTION
Resolves #1

### Overview

This pull request introduces and improves the following features:

- **URL query injection**: Allows passing a `q` parameter (e.g. `?q=wheel+of+time`) that populates and immediately triggers the "Find Books" search on app load.
- **Initial tab selection**: Ensures that, when using a `q` parameter, the app waits for libraries to be ready before jumping to the correct tab and starting the search.
- **Controlled Tabs support and API cleanup**: Refactors the `Tabs` component to support a fully controlled mode using `tabIndex` and `setTabIndex`. Removes the `defaultTabIndex` prop and migrates all usages and tests to the new API.

### Details

- **BookSearch.tsx**: The component now waits for both libraries and an initial query to be present before running a search, which ensures correct and visible behaviour if the app is launched with a `q` parameter.
- **App.tsx**: Uses controlled tab state so the application automatically navigates to the "Find Books" tab, but only once all async state (libraries, query) is ready.
- **Tabs.tsx**:
    - Adds `tabIndex` and `setTabIndex` for controlled mode. Needed because the `initialQuery` variable is present in the `App` component
    - Removes support for `defaultTabIndex`.
